### PR TITLE
Add `diffSync`

### DIFF
--- a/lib/calculate.dart
+++ b/lib/calculate.dart
@@ -87,15 +87,7 @@ Future<List<Operation<Item>>> _calculateDiff<Item>(
   List<Item> newList,
   bool Function(Item a, Item b) areEqual,
 ) async {
-  var row = <_Sequence<Item>>[];
-
-  for (var x = 0; x <= oldList.length; x++) {
-    if (x == 0) {
-      row.add(_Sequence.unchanged(null));
-    } else {
-      row.add(_Sequence.delete(row.last, oldList[x - 1]));
-    }
-  }
+  var row = _getInitialRow(oldList);
 
   for (var y = 0; y < newList.length; y++) {
     final nextRow = <_Sequence<Item>>[];
@@ -140,15 +132,7 @@ List<Operation<Item>> _calculateDiffSync<Item>(
 ) {
   assert(Item is! _ReferenceToItemOnOtherIsolate);
 
-  var row = <_Sequence<Item>>[];
-
-  for (var x = 0; x <= oldList.length; x++) {
-    if (x == 0) {
-      row.add(_Sequence.unchanged(null));
-    } else {
-      row.add(_Sequence.delete(row.last, oldList[x - 1]));
-    }
-  }
+  var row = _getInitialRow(oldList);
 
   for (var y = 0; y < newList.length; y++) {
     final nextRow = <_Sequence<Item>>[];
@@ -169,4 +153,18 @@ List<Operation<Item>> _calculateDiffSync<Item>(
   }
 
   return row.last.toOperations();
+}
+
+List<_Sequence<Item>> _getInitialRow<Item>(List<Item> oldList) {
+  final row = <_Sequence<Item>>[];
+
+  for (var x = 0; x <= oldList.length; x++) {
+    if (x == 0) {
+      row.add(_Sequence.unchanged(null));
+    } else {
+      row.add(_Sequence.delete(row.last, oldList[x - 1]));
+    }
+  }
+  ;
+  return row;
 }

--- a/lib/calculate.dart
+++ b/lib/calculate.dart
@@ -53,7 +53,7 @@ class _Sequence<Item> {
 }
 
 // This algorithm works by filling out a table with the two lists at the
-// axises, where a cell at position x,y represents the number of operations
+// axes, where a cell at position x,y represents the number of operations
 // needed to get from the first x items of the first list to the first y items
 // of the second one.
 // Let's say, the old list is [a, b] and the new one is [a, c]. The following

--- a/lib/list_diff.dart
+++ b/lib/list_diff.dart
@@ -3,11 +3,14 @@
 library list_diff;
 
 import 'dart:isolate';
-import 'package:async/async.dart';
 
-part 'operation.dart';
+import 'package:async/async.dart';
+import 'package:meta/meta.dart';
+
 part 'calculate.dart';
 part 'isolated.dart';
+part 'operation.dart';
+part 'trim.dart';
 
 /// Calculates a minimal list of [Operation]s that convert the [oldList] into
 /// the [newList].
@@ -82,54 +85,27 @@ Future<List<Operation<Item>>> diff<Item>(
   areEqual ??= (a, b) => a == b;
   getHashCode ??= (item) => item.hashCode;
 
-  // Check if the lists start or end with the same items to trim the problem
-  // down as much as possible.
-  final oldLen = oldList.length;
-  final newLen = newList.length;
-  var start = 0;
-  while (start < oldLen &&
-      start < newLen &&
-      areEqual(oldList[start], newList[start])) {
-    start++;
-  }
-  var end = 0;
-  while (end < oldLen &&
-      end < newLen &&
-      areEqual(oldList[oldLen - 1 - end], newList[newLen - 1 - end])) {
-    end++;
-  }
-  // We can now reduce the problem to two possibly smaller sublists.
-  final shortenedOldList =
-      oldLen == end ? <Item>[] : oldList.sublist(start, oldLen - end);
-  final shortenedNewList =
-      newLen == end ? <Item>[] : newList.sublist(start, newLen - end);
+  final trimResult = _trim(oldList, newList, areEqual);
 
-  // If no [spawnIsolate] is given, we try to automatically choose a value that
-  // aligns with our performance goals.
-  // The algorithm fills an N times M table of cells, where N and M are the
-  // lengths of both lists. Because most Dart code is eventually used in
-  // Flutter as AOT-compiled code, I did some performance testing on a
-  // OnePlus 6T. Turns out, spawning an isolate and transmitting the necessary
-  // data takes about 13 ms and filling one cell about 4 µs.
-  // Let's say an app wants to achieve 90 fps (that may seem like a stretch,
-  // but keep in mind that there are lots of less-performant devices, so the
-  // benchmark speeds are taken with an upper-bound-ish kind of view).
-  // That leaves us with about 11 ms per frame. Because there's probably a lot
-  // of other stuff happening apart from calculating the differences (like,
-  // actually animating stuff and building widgets), let's say we want the diff
-  // to at most take up half of the time, so at most 6 ms.
-  // Whether we should spawn an isolate only depends on if we can fit the
-  // calculation of the N*M cells into the timeframe of 6 ms. With a cell
-  // calculation time of 4 µs, we can calculate the value of
-  // 6 ms / 4 µs = 1.500 cells to still be able to hit our deadline.
-  spawnIsolate ??= shortenedOldList.length * shortenedNewList.length > 1500;
+  spawnIsolate ??= _shouldSpawnIsolate(
+    trimResult.shortenedOldList,
+    trimResult.shortenedNewList,
+  );
 
   // Those are sublists that reduce the problem to a smaller problem domain.
   List<Operation<Item>> operations = await (spawnIsolate
       ? _calculateDiffInSeparateIsolate(
-          shortenedOldList, shortenedNewList, areEqual, getHashCode)
-      : _calculateDiff(shortenedOldList, shortenedNewList, areEqual));
+          trimResult.shortenedOldList,
+          trimResult.shortenedNewList,
+          areEqual,
+          getHashCode,
+        )
+      : _calculateDiff(
+          trimResult.shortenedOldList,
+          trimResult.shortenedNewList,
+          areEqual,
+        ));
 
   // Shift operations back.
-  return operations.map((op) => op._shift(start)).toList();
+  return operations.map((op) => op._shift(trimResult.start)).toList();
 }

--- a/lib/trim.dart
+++ b/lib/trim.dart
@@ -1,0 +1,47 @@
+part of 'list_diff.dart';
+
+/// Check if the lists start or end with the same items to trim the problem down
+/// as much as possible.
+_TrimResult<Item> _trim<Item>(
+  List<Item> oldList,
+  List<Item> newList,
+  bool Function(Item a, Item b) areEqual,
+) {
+  final oldLen = oldList.length;
+  final newLen = newList.length;
+  var start = 0;
+  while (start < oldLen &&
+      start < newLen &&
+      areEqual(oldList[start], newList[start])) {
+    start++;
+  }
+  var end = 0;
+  while (end < oldLen &&
+      end < newLen &&
+      areEqual(oldList[oldLen - 1 - end], newList[newLen - 1 - end])) {
+    end++;
+  }
+
+  // We can now reduce the problem to two possibly smaller sublists.
+  return _TrimResult(
+    shortenedOldList:
+        oldLen == end ? <Item>[] : oldList.sublist(start, oldLen - end),
+    shortenedNewList:
+        newLen == end ? <Item>[] : newList.sublist(start, newLen - end),
+    start: start,
+  );
+}
+
+class _TrimResult<Item> {
+  const _TrimResult({
+    @required this.shortenedOldList,
+    @required this.shortenedNewList,
+    @required this.start,
+  })  : assert(shortenedOldList != null),
+        assert(shortenedNewList != null),
+        assert(start != null);
+
+  final List<Item> shortenedOldList;
+  final List<Item> shortenedNewList;
+  final int start;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -142,7 +142,7 @@ packages:
     source: hosted
     version: "0.12.6"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   async: ">=2.2.0 <2.5.0"
+  meta: ^1.1.8
 
 dev_dependencies:
   test: ^1.9.4


### PR DESCRIPTION
This PR adds a `diffSync` variant for when you only have small lists to compare and need a synchronous response (i.e., without using a `Future`).